### PR TITLE
configurable shadows from .scn

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -296,8 +296,8 @@ export default e => {
             csm.setupMaterial(o.material);
           } */
           o.frustumCulled = false;
-          // o.castShadow = true;
-          // o.receiveShadow = true;
+          o.castShadow = true;
+          o.receiveShadow = true;
         }
       });      
       

--- a/type_templates/light.js
+++ b/type_templates/light.js
@@ -19,12 +19,28 @@ export default e => {
 
   const srcUrl = '${this.srcUrl}';
   // console.log('got light', {srcUrl});
+
+
+  const addShadows = (light, params) => {
+    light.castShadow = true; 
+    light.shadow.mapSize.width = params[1]; 
+    light.shadow.mapSize.height = params[1]; 
+    light.shadow.camera.near = params[2];
+    light.shadow.camera.far = params[3];
+    light.shadow.camera.left = params[0];
+    light.shadow.camera.right = -params[0];
+    light.shadow.camera.top = params[0];
+    light.shadow.camera.bottom = -params[0];
+    light.shadow.bias = params[4];
+    console.log("Added shadows for:", light, "with params:", params);
+  };
+
   
   const lights = [];
   (async () => {
     const res = await fetch(srcUrl);
     const j = await res.json();
-    let {lightType, args, position} = j;
+    let {lightType, args, position, shadow} = j;
     const light = (() => {
       switch (lightType) {
         case 'ambient': {
@@ -84,6 +100,11 @@ export default e => {
         new THREE.Vector3();
       light.offsetMatrix = new THREE.Matrix4().makeTranslation(p.x, p.y, p.z);
       light.lastAppMatrixWorld = new THREE.Matrix4();
+
+      if(lightType === 'directional' || lightType === 'point' || lightType === 'spot') {
+        const s = (Array.isArray(shadow) && shadow.length === 5 && shadow.every(n => typeof n === 'number')) ?
+        addShadows(light, shadow) : console.log("Error in shadow params, or no active shadows");
+      }
 
       const worldLights = world.getLights();
       worldLights.add(light);

--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -146,6 +146,8 @@ export default e => {
         for (const skinnedMesh of skinnedMeshes) {
           const {geometry, material, position, quaternion, scale, matrix, matrixWorld, visible, parent} = skinnedMesh;
           const mesh = new THREE.Mesh(geometry, material);
+          mesh.castShadow = true;
+          mesh.receiveShadow = true;
           mesh.position.copy(position);
           mesh.quaternion.copy(quaternion);
           mesh.scale.copy(scale);


### PR DESCRIPTION
Shadows are configurable in the .scn file.

Usage: 
`"shadow": [150, 5120, 0.1, 1000, -0.0001]` (side, mapSize, near, far, bias)

Shadows are not enabled for the main avatar yet. Still need to fix the issue with render ordering.
This PR does not break any current system and shadows are completely optional.