### PR TITLE
Windows path slash issue causing the failure in metaverse files to load

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-react": "^7.14.5",
     "mime-types": "^2.1.32",
     "node-fetch": "^2.6.1",
-    "pako": "^2.0.4"
+    "pako": "^2.0.4",
+    "unix-path": "^0.2.0"
   }
 }


### PR DESCRIPTION
The error which has been faced over the Windows is that it was using the backward slash in the path while the application was trying to check for the path based on forward slashes for which almost major loaders now contain the checks for windows and convert backward slashes to forwards.

Additionally, a check for process.platform is added so if the URL still has backward slashes it should be converted into forward slashes as well.