### PR TITLE
Text node support

### DIFF
--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -26,6 +26,7 @@ const glbb = require('../types/glbb.js');
 const html = require('../types/html.js');
 const scn = require('../types/scn.js');
 const light = require('../types/light.js');
+const text = require('../types/text.js');
 //const fog = require('../types/fog.js');
 // const background = require('../types/background.js');
 const rendersettings = require('../types/rendersettings.js');
@@ -47,6 +48,7 @@ const loaders = {
   html,
   scn,
   light,
+  text,
   // fog,
   // background,
   rendersettings,
@@ -69,7 +71,7 @@ const _getType = id => {
     }
     let extension;
     let match2;
-    if (match2 = type.match(/^application\/(light|rendersettings|group)$/)) {
+    if (match2 = type.match(/^application\/(light|text|rendersettings|group)$/)) {
       extension = match2[1];
     } else {
       extension = mimeTypes.extension(type);

--- a/type_templates/text.js
+++ b/type_templates/text.js
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
-import {Text} from 'troika-three-text';
 import metaversefile from 'metaversefile';
-const {useApp, useFrame, useLocalPlayer} = metaversefile;
+const {useApp, useFrame, useLocalPlayer, useTextInternal} = metaversefile;
 
+const Text = useTextInternal();
 function makeTextMesh(
   text = '',
   font = './assets/fonts/GeosansLight.ttf',

--- a/type_templates/text.js
+++ b/type_templates/text.js
@@ -30,14 +30,14 @@ export default e => {
   
   const srcUrl = '${this.srcUrl}';
   
-  (async () => {
+  e.waitUntil((async () => {
     const res = await fetch(srcUrl);
     const j = await res.json();
     const {text, font, fontSize, anchorX, anchorY, color} = j;
     const textMesh = makeTextMesh(text, font, fontSize, anchorX, anchorY, color);
     app.add(textMesh);
     app.text = textMesh;
-  })();
+  })());
 
   return app;
 };

--- a/type_templates/text.js
+++ b/type_templates/text.js
@@ -26,6 +26,7 @@ function makeTextMesh(
 export default e => {
   const app = useApp();
   app.appType = 'text';
+  app.text = null;
   
   const srcUrl = '${this.srcUrl}';
   
@@ -35,6 +36,7 @@ export default e => {
     const {text, font, fontSize, anchorX, anchorY, color} = j;
     const textMesh = makeTextMesh(text, font, fontSize, anchorX, anchorY, color);
     app.add(textMesh);
+    app.text = textMesh;
   })();
 
   return app;

--- a/type_templates/text.js
+++ b/type_templates/text.js
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import {Text} from 'troika-three-text';
+import metaversefile from 'metaversefile';
+const {useApp, useFrame, useLocalPlayer} = metaversefile;
+
+function makeTextMesh(
+  text = '',
+  font = './assets/fonts/GeosansLight.ttf',
+  fontSize = 1,
+  anchorX = 'left',
+  anchorY = 'middle',
+  color = 0x000000,
+) {
+  const textMesh = new Text();
+  textMesh.text = text;
+  textMesh.font = font;
+  textMesh.fontSize = fontSize;
+  textMesh.color = color;
+  textMesh.anchorX = anchorX;
+  textMesh.anchorY = anchorY;
+  textMesh.frustumCulled = false;
+  textMesh.sync();
+  return textMesh;
+}
+
+export default e => {
+  const app = useApp();
+  app.appType = 'text';
+  
+  const srcUrl = '${this.srcUrl}';
+  
+  (async () => {
+    const res = await fetch(srcUrl);
+    const j = await res.json();
+    const {text, font, fontSize, anchorX, anchorY, color} = j;
+    const textMesh = makeTextMesh(text, font, fontSize, anchorX, anchorY, color);
+    app.add(textMesh);
+  })();
+
+  return app;
+};

--- a/types/text.js
+++ b/types/text.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const fs = require('fs');
+const {fillTemplate} = require('../util.js');
+
+const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'text.js'), 'utf8');
+const cwd = process.cwd();
+
+module.exports = {
+  load(id) {
+    if (id.startsWith(cwd)) {
+      id = id.slice(cwd.length);
+    }
+    const code = fillTemplate(templateString, {
+      srcUrl: id,
+    });
+    // console.log('got image id', id);
+    return {
+      code,
+      map: null,
+    };
+  },
+};


### PR DESCRIPTION
Adds text nodes support using https://www.npmjs.com/package/troika-three-text. You can add text nodes to scenes like so, using the `application/text` MIME type:

```
{
      "type": "application/text",
      "content": {
        "text": "S.L.Y",
        "font": "./fonts/Bangers-Regular.ttf",
        "fontSize": 1,
        "anchorX": "left",
        "anchorY": "middle",
        "color": [255, 255, 255]
      },
      "position": [
        0,
        2,
        4
      ]
    },
```

Custom fonts are supported.