### PR TITLE
Gltj support

### DIFF
--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -23,6 +23,7 @@ const vox = require('../types/vox.js');
 const image = require('../types/image.js');
 const gif = require('../types/gif.js');
 const glbb = require('../types/glbb.js');
+const gltj = require('../types/gltj.js');
 const html = require('../types/html.js');
 const scn = require('../types/scn.js');
 const light = require('../types/light.js');
@@ -45,6 +46,7 @@ const loaders = {
   svg: image,
   gif,
   glbb,
+  gltj,
   html,
   scn,
   light,

--- a/type_templates/gltj.js
+++ b/type_templates/gltj.js
@@ -1,0 +1,59 @@
+import * as THREE from 'three';
+import metaversefile from 'metaversefile';
+const {useApp, useFrame, useLoaders, useScene, useCleanup} = metaversefile;
+
+const size = 1024;
+const worldSize = 2;
+
+export default () => {
+  const app = useApp();
+  app.appType = 'glfs';
+  
+  const physics = usePhysics();
+  
+  const o = new THREE.Object3D();
+  app.add(o);
+  
+  let _update = null;
+  
+  const srcUrl = '${this.srcUrl}';
+  (async () => {
+    const {shadertoyLoader} = useLoaders();
+    const shadertoyRenderer = await shadertoyLoader.load(srcUrl, {
+      size,
+      worldSize,
+    });
+    // await shadertoyRenderer.waitForLoad();
+    o.add(shadertoyRenderer.mesh);
+    _update = timeDiff => {
+      shadertoyRenderer.update(timeDiff/1000);
+    };
+  })();
+  
+  let physicsIds = [];
+  let staticPhysicsIds = [];
+  const _run = () => {
+    const physicsId = physics.addBoxGeometry(
+      new THREE.Vector3(),
+      new THREE.Quaternion(),
+      new THREE.Vector3(worldSize/2, worldSize/2, 0.01),
+      false
+    );
+    physicsIds.push(physicsId);
+    staticPhysicsIds.push(physicsId);
+  };
+  _run();
+  useCleanup(() => {
+    for (const physicsId of physicsIds) {
+      physics.removeGeometry(physicsId);
+    }
+    physicsIds.length = 0;
+    staticPhysicsIds.length = 0;
+  });
+
+  useFrame(({timeDiff}) => {
+    _update && _update(timeDiff);
+  });
+
+  return app;
+};

--- a/type_templates/gltj.js
+++ b/type_templates/gltj.js
@@ -19,8 +19,6 @@ export default e => {
     
     const material = new THREE.ShaderMaterial(j);
     
-    console.log('got', j, material);
-    
     const mesh = new THREE.Mesh(geometry, material);
     mesh.frustumCulled = false;
     app.add(mesh);

--- a/type_templates/gltj.js
+++ b/type_templates/gltj.js
@@ -1,7 +1,8 @@
 import * as THREE from 'three';
 import metaversefile from 'metaversefile';
-const {useApp, useFrame, useLoaders, useScene, usePhysics, useJSON6Internal, useCleanup} = metaversefile;
+const {useApp, useFrame, useLoaders, useScene, usePhysics, useInternals, useJSON6Internal, useCleanup} = metaversefile;
 
+const {renderer} = useInternals();
 const JSON6 = useJSON6Internal();
 const geometry = new THREE.PlaneBufferGeometry(2, 2);
 
@@ -28,6 +29,14 @@ export default e => {
       if (material.uniforms.iTime) {
         material.uniforms.iTime.value = now/1000;
         material.uniforms.iTime.needsUpdate = true;
+      }
+      if (material.uniforms.iResolution) {
+        if (!material.uniforms.iResolution.value) {
+          material.uniforms.iResolution.value = new THREE.Vector2();
+        }
+        renderer.getSize(material.uniforms.iResolution.value)
+          .multiplyScalar(renderer.getPixelRatio());
+        material.uniforms.iResolution.needsUpdate = true;
       }
       
       now += timeDiff;

--- a/types/gltj.js
+++ b/types/gltj.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const fs = require('fs');
+const {fillTemplate} = require('../util.js');
+
+const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'gltj.js'), 'utf8');
+const cwd = process.cwd();
+
+module.exports = {
+  load(id) {
+    if (id.startsWith(cwd)) {
+      id = id.slice(cwd.length);
+    }
+    // console.log('load glbb', id);
+    const code = fillTemplate(templateString, {
+      srcUrl: id,
+    });
+    return {
+      code,
+      map: null,
+    };
+  },
+};


### PR DESCRIPTION
GL ThreeJs support.

This add support for THREE.js shader material definitions in a file, which will render as background planes by default. Useful for effects.