### PR TITLE
Glb to vrm hack

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -479,8 +479,7 @@ export default e => {
                   };
                   humanBones.push(boneSpec);
                 } else {
-                  console.log('failed to find bone', boneName, bone);
-                  debugger;
+                  console.log('failed to find bone', boneNodeMapping, k, nodes, boneNodeIndex);
                 }
               }
               glb.parser.json.extensions = {

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -406,6 +406,92 @@ export default e => {
             app.scale.set(1, 1, 1)//.multiplyScalar(wearableScale);
             app.updateMatrix();
             app.matrixWorld.copy(app.matrix);
+            
+            // this adds pseudo-VRM onto our GLB assuming a mixamo rig
+            // used for the glb wearable skinning feature
+            const _mixamoRigToFakeVRMHack = () => {
+              const {nodes} = glb.parser.json;
+              const boneNodeMapping = {
+                hips: 'J_Bip_C_Hips',
+                leftUpperLeg: 'J_Bip_L_UpperLeg',
+                rightUpperLeg: 'J_Bip_R_UpperLeg',
+                leftLowerLeg: 'J_Bip_L_LowerLeg',
+                rightLowerLeg: 'J_Bip_R_LowerLeg',
+                leftFoot: 'J_Bip_L_Foot',
+                rightFoot: 'J_Bip_R_Foot',
+                spine: 'J_Bip_C_Spine',
+                chest: 'J_Bip_C_Chest',
+                neck: 'J_Bip_C_Neck',
+                head: 'J_Bip_C_Head',
+                leftShoulder: 'J_Bip_L_Shoulder',
+                rightShoulder: 'J_Bip_R_Shoulder',
+                leftUpperArm: 'J_Bip_L_UpperArm',
+                rightUpperArm: 'J_Bip_R_UpperArm',
+                leftLowerArm: 'J_Bip_L_LowerArm',
+                rightLowerArm: 'J_Bip_R_LowerArm',
+                leftHand: 'J_Bip_L_Hand',
+                rightHand: 'J_Bip_R_Hand',
+                leftToes: 'J_Bip_L_ToeBase',
+                rightToes: 'J_Bip_R_ToeBase',
+                leftEye: 'J_Adj_L_FaceEye',
+                rightEye: 'J_Adj_R_FaceEye',
+                leftThumbProximal: 'J_Bip_L_Thumb1',
+                leftThumbIntermediate: 'J_Bip_L_Thumb2',
+                leftThumbDistal: 'J_Bip_L_Thumb3',
+                leftIndexProximal: 'J_Bip_L_Index1',
+                leftIndexIntermediate: 'J_Bip_L_Index2',
+                leftIndexDistal: 'J_Bip_L_Index3',
+                leftMiddleProximal: 'J_Bip_L_Middle1',
+                leftMiddleIntermediate: 'J_Bip_L_Middle2',
+                leftMiddleDistal: 'J_Bip_L_Middle3',
+                leftRingProximal: 'J_Bip_L_Ring1',
+                leftRingIntermediate: 'J_Bip_L_Ring2',
+                leftRingDistal: 'J_Bip_L_Ring3',
+                leftLittleProximal: 'J_Bip_L_Little1',
+                leftLittleIntermediate: 'J_Bip_L_Little2',
+                leftLittleDistal: 'J_Bip_L_Little3',
+                rightThumbProximal: 'J_Bip_R_Thumb1',
+                rightThumbIntermediate: 'J_Bip_R_Thumb2',
+                rightThumbDistal: 'J_Bip_R_Thumb3',
+                rightIndexProximal: 'J_Bip_R_Index1',
+                rightIndexIntermediate: 'J_Bip_R_Index2',
+                rightIndexDistal: 'J_Bip_R_Index3',
+                rightMiddleProximal: 'J_Bip_R_Middle3',
+                rightMiddleIntermediate: 'J_Bip_R_Middle2',
+                rightMiddleDistal: 'J_Bip_R_Middle1',
+                rightRingProximal: 'J_Bip_R_Ring1',
+                rightRingIntermediate: 'J_Bip_R_Ring2',
+                rightRingDistal: 'J_Bip_R_Ring3',
+                rightLittleProximal: 'J_Bip_R_Little1',
+                rightLittleIntermediate: 'J_Bip_R_Little2',
+                rightLittleDistal: 'J_Bip_R_Little3',
+                upperChest: 'J_Bip_C_UpperChest',
+              };
+              const humanBones = [];
+              for (const k in boneNodeMapping) {
+                const boneName = boneNodeMapping[k];
+                const boneNodeIndex = nodes.findIndex(node => node.name === boneName);
+                if (boneNodeIndex !== -1) {
+                  const boneSpec = {
+                    bone: k,
+                    node: boneNodeIndex,
+                    // useDefaultValues: true, // needed?
+                  };
+                  humanBones.push(boneSpec);
+                } else {
+                  console.log('failed to find bone', boneName, bone);
+                  debugger;
+                }
+              }
+              glb.parser.json.extensions = {
+                VRM: {
+                  humanoid: {
+                    humanBones,
+                  }
+                },
+              };
+            };
+            _mixamoRigToFakeVRMHack();
             const bindSpec = Avatar.bindAvatar(glb);
 
             // skeleton = bindSpec.skeleton;


### PR DESCRIPTION
This adds fake VRM metadata for the GLB mixamo skinning case, so that the avatar.js avatars binding works to correctly implement simultaneous skinning of the two rigs.