### PR TITLE
Update avatar models to use MToonMaterial

### DIFF
--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -39,13 +39,7 @@ const _findMaterialsObjects = (o, name) => {
 const _toonShaderify = async o => {
   const vrmExtension = o.userData.gltfExtensions.VRM;
   const vrmImporter = new VRMMaterialImporter();
-  const materials = await vrmImporter.convertGLTFMaterials(o);
-  for (const material of materials) {
-      const objects = _findMaterialsObjects(o.scene, material.name);
-      objects.forEach(o=>{
-        o.material = material;
-      })
-  }
+  await vrmImporter.convertGLTFMaterials(o);
 };
 
 export default e => {


### PR DESCRIPTION
This PR enables use of MToonMaterial. 

Please look at the first 2 images for comparison. 

The last image is an art reference.

![image](https://user-images.githubusercontent.com/51108458/143209250-24a2d73e-4e26-4240-8be8-326a805019a1.png)
![image](https://user-images.githubusercontent.com/51108458/143209264-e34d5d6c-4479-4b38-9297-0d0e97aa092d.png)
![image](https://user-images.githubusercontent.com/51108458/143209486-710ba112-a857-48ef-b292-7cd232a62850.png)

QA Checklist:

Look at the avatar face in the mirror, and up close with the camera, you should see some 'toon' shading.
Look at the avatar hair and body, you should see movement in the hair and other parts that might contain a 'springy' animation.
