### PR TITLE
set gltj app uniforms from scn & timestamp in gltj _update function

### DIFF
--- a/type_templates/gltj.js
+++ b/type_templates/gltj.js
@@ -11,41 +11,46 @@ export default e => {
   app.appType = 'gltj';
 
   const srcUrl = '${this.srcUrl}';
-  
+
   let _update = null;
   e.waitUntil((async () => {
-    const res = await fetch(srcUrl);
-    const s = await res.text();
-    const j = JSON6.parse(s);
-    
-    const material = new THREE.ShaderMaterial(j);
-    
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.frustumCulled = false;
-    app.add(mesh);
-    
-    let now = 0;
-    _update = timeDiff => {
-      if (material.uniforms.iTime) {
-        material.uniforms.iTime.value = now/1000;
-        material.uniforms.iTime.needsUpdate = true;
-      }
-      if (material.uniforms.iResolution) {
-        if (!material.uniforms.iResolution.value) {
-          material.uniforms.iResolution.value = new THREE.Vector2();
-        }
-        renderer.getSize(material.uniforms.iResolution.value)
-          .multiplyScalar(renderer.getPixelRatio());
-        material.uniforms.iResolution.needsUpdate = true;
-      }
-      
-      now += timeDiff;
-    };
-  })());
+      const res = await fetch(srcUrl);
+      const s = await res.text();
+      const j = JSON6.parse(s);
 
-  useFrame(({timeDiff}) => {
-    _update && _update(timeDiff);
-  });
+      const material = new THREE.ShaderMaterial(j);
+
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.frustumCulled = false;
+      app.add(mesh);
+
+      const uniforms = app.getComponent("uniforms");
+      for (const name in uniforms) {
+        material.uniforms[name].value = uniforms[name];
+      }
+
+      let now = 0;
+      _update = timeDiff => {
+        if (material.uniforms.iTime) {
+          material.uniforms.iTime.value = now/1000;
+          material.uniforms.iTime.needsUpdate = true;
+        }
+        if (material.uniforms.iResolution) {
+          if (!material.uniforms.iResolution.value) {
+            material.uniforms.iResolution.value = new THREE.Vector2();
+          }
+          renderer.getSize(material.uniforms.iResolution.value)
+            .multiplyScalar(renderer.getPixelRatio());
+          material.uniforms.iResolution.needsUpdate = true;
+        }
+
+        now += timeDiff;
+      };
+    })());
+
+    useFrame(({timeDiff}) => {
+      _update && _update(timeDiff);
+    });
 
   return app;
 };

--- a/type_templates/gltj.js
+++ b/type_templates/gltj.js
@@ -30,10 +30,14 @@ export default e => {
       }
 
       let now = 0;
-      _update = timeDiff => {
+      _update = (timestamp, timeDiff) => {
         if (material.uniforms.iTime) {
           material.uniforms.iTime.value = now/1000;
           material.uniforms.iTime.needsUpdate = true;
+        }
+        if(material.uniforms.iTimeS) {
+          material.uniforms.iTimeS.value = timestamp/1000;
+          material.uniforms.iTimeS.needsUpdate = true;
         }
         if (material.uniforms.iResolution) {
           if (!material.uniforms.iResolution.value) {
@@ -48,9 +52,9 @@ export default e => {
       };
     })());
 
-    useFrame(({timeDiff}) => {
-      _update && _update(timeDiff);
-    });
+  useFrame(({timestamp, timeDiff}) => {
+    _update && _update(timestamp, timeDiff);
+  });
 
   return app;
 };


### PR DESCRIPTION
1. GLTJ app declared uniforms values can be now set from .scn file:
{
"start_url": "{URL to GLTJ APP}",
"components": [
{
    "key": "uniforms",
    "value": {
    "{uniform name}": {uniform value},
    "{uniform name}": {uniform value},
    }
}
]
}

2. Introduced timestamp in gltj _update function. The timestamp is global which helps syncing gltj app with some other animation loop using the timestamp there as well. 
 